### PR TITLE
fix: mark async_hooks as external

### DIFF
--- a/.changeset/shiny-knives-obey.md
+++ b/.changeset/shiny-knives-obey.md
@@ -1,0 +1,5 @@
+---
+'@fleek-platform/next-on-fleek': patch
+---
+
+Mark `async_hooks` as external.

--- a/packages/next-on-fleek/src/buildApplication/buildWorkerFile.ts
+++ b/packages/next-on-fleek/src/buildApplication/buildWorkerFile.ts
@@ -88,7 +88,12 @@ export async function buildWorkerFile(
 		banner: { js: generateGlobalJs() },
 		bundle: true,
 		inject: [functionsFile],
-		external: ['node:*', './__next-on-fleek-dist__/*', 'cloudflare:*'],
+		external: [
+			'node:*',
+			'async_hooks',
+			'./__next-on-fleek-dist__/*',
+			'cloudflare:*',
+		],
 		define: {
 			__CONFIG__: JSON.stringify(vercelConfig),
 			__NODE_ENV__: JSON.stringify(getNodeEnv()),

--- a/packages/next-on-fleek/src/buildApplication/processVercelFunctions/build.ts
+++ b/packages/next-on-fleek/src/buildApplication/processVercelFunctions/build.ts
@@ -36,7 +36,13 @@ export async function buildFile(
 		platform: 'neutral',
 		outfile: filePath,
 		bundle: true,
-		external: ['node:*', `${relativeNopDistPath}/*`, '*.wasm', 'cloudflare:*'],
+		external: [
+			'node:*',
+			'async_hooks',
+			`${relativeNopDistPath}/*`,
+			'*.wasm',
+			'cloudflare:*',
+		],
 		minify: false,
 		plugins: [builtInModulesPlugin],
 		loader: { '.ttf': 'file' },
@@ -96,21 +102,24 @@ type RelativePathOpts = {
  * breaks at runtime. The following fixes this by updating the dynamic require to a standard esm
  * import from the built-in module.
  *
- * This applies to `require("node:*")` and `require("cloudflare:*")`.
+ * This applies to `require("node:*")`, `require("cloudflare:*")`, and `require("async_hooks")`.
  */
 export const builtInModulesPlugin: Plugin = {
 	name: 'built-in:modules',
 	setup(build) {
-		build.onResolve({ filter: /^(node|cloudflare):/ }, ({ kind, path }) => {
-			/**
-			 * This plugin converts `require("<PREFIX>:*")` calls, those are the only ones that need
-			 * updating (esm imports to "<PREFIX>:*" are totally valid), so here we tag with the
-			 * built-in-modules namespace only imports that are require calls.
-			 */
-			return kind === 'require-call'
-				? { path, namespace: 'built-in-modules' }
-				: undefined;
-		});
+		build.onResolve(
+			{ filter: /^(node:|cloudflare:|async_hooks)/ },
+			({ kind, path }) => {
+				/**
+				 * This plugin converts `require("<PREFIX>:*")` calls, those are the only ones that need
+				 * updating (esm imports to "<PREFIX>:*" are totally valid), so here we tag with the
+				 * built-in-modules namespace only imports that are require calls.
+				 */
+				return kind === 'require-call'
+					? { path, namespace: 'built-in-modules' }
+					: undefined;
+			}
+		);
 
 		/**
 		 * We convert the imports we tagged with the built-in-modules namespace so that instead of


### PR DESCRIPTION
Compatibility in `async_hooks` has been broken in `vercel v39.1.2` and later and must be addressed.
This PR is based on https://github.com/cloudflare/next-on-pages/pull/909.